### PR TITLE
Fix example code

### DIFF
--- a/src/ch1/money.clj
+++ b/src/ch1/money.clj
@@ -34,7 +34,7 @@
   ([m1 m2 & monies]
    (reduce +$ m1 (conj monies m2))))
 
-(defn *$ [m n] (->Money (* n (:amounr m)) (:currency m)))
+(defn *$ [m n] (->Money (* n (:amount m)) (:currency m)))
 
 (defn make-money
   ([] (make-money 0))

--- a/src/ch1/money.clj
+++ b/src/ch1/money.clj
@@ -38,7 +38,7 @@
 
 (defn make-money
   ([] (make-money 0))
-  ([amount] (make-money amount :usd))
+  ([amount] (make-money amount (:usd currencies)))
   ([amount currency] (->Money amount currency)))
 
 


### PR DESCRIPTION
Hey @brianium,

I am not sure whether this is important or not but I have cloned your repository (thanks by the way, it helped me get started ^^) and stumbled upon a little inconsistency related to one of the examples in the first chapter of the "Clojure Applied" book. This is a little patch to fix it ;-)

According to the book (the section about : **Positional destructuring**), calling `(make-money)` should provide the following output :

```
(make-money)
=> #ch1.money.Money{:amount 0, :currency #ch1.money.Currency{:divisor 100, :sym "USD", :desc "US Dollars"}}
```

but the problem is that, we defined the `make-money` function like this : 

```
(defn make-money
  ([] (make-money 0))
  ([amount] (make-money amount :usd))
  ([amount currency] (->Money amount currency)))
```
The second arity of the function uses `:usd` (a keyword) as the second argument of the `make-money` function, hence the output is : 

```
(make-money)
=> #ch1.money.Money{:amount 0, :currency :usd}
```
The `Money` record definition (hence its _positional factory method_) is expecting a `Currency` entity as a second argument instead of a _keyword_.

I hope it helped ;-)

P.S: also fixed a little typo ^^